### PR TITLE
Patches from openvino dldt branch

### DIFF
--- a/inference-engine/src/gna_plugin/backend/make_pwl.cpp
+++ b/inference-engine/src/gna_plugin/backend/make_pwl.cpp
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+#define PWL_FROM_FILE
+
 #include <vector>
 #include <iostream>
 
@@ -151,6 +153,8 @@ void make_gna_pwl(const DnnActivation  fun,
             s = gna_slope(1.0, in_scale, out_scale);
             gna_pwl[1].slope = FLOAT_TO_INT16(s.slope * s.slope_scale);
             gna_pwl[1].xBase = gna_pwl[1].xBase | s.slope_scale_index;
+            int32_t round_scale = FLOAT_TO_INT16(0.5f / s.slope) & XBASEMASK;
+            gna_pwl[1].xBase = (gna_pwl[1].xBase - round_scale) | s.slope_scale_index;
             gnalog() << gna_pwl[1].xBase / in_scale
                      << " " << gna_pwl[1].yBase / out_scale
                      << " " << 1.0

--- a/inference-engine/src/gna_plugin/gna_plugin.cpp
+++ b/inference-engine/src/gna_plugin/gna_plugin.cpp
@@ -519,6 +519,18 @@ void GNAPlugin::LoadNetwork(ICNNNetwork &network) {
         // gets output layer pointer in original topology not in cloned
         auto outLayer = outPort.second->getCreatorLayer().lock();
 
+        // Memory layers are not dnnComponents hence we need to make switch with identity layer
+        if (outLayer->type == "Memory") {
+            // traverse memory connection to find corresponding output_memory
+            for (auto && memConnection : graphCompiler.memory_connection) {
+                if (memConnection.second.getInput()->name == outLayer->name) {
+                    // if connection is found, replace memory input layer with memory output layer
+                    outLayer = memConnection.second.getOutput();
+                    break;
+                }
+            }
+        }
+
         // searching for outData represented in GNA blob
         // using ufs - upper first search
         gnalog() << "[UFS] searching for : "<< outPort.first << " representation in GNA\n";

--- a/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/other_tests/add_output.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/other_tests/add_output.cpp
@@ -1,0 +1,16 @@
+// Copyright (C) 2020 Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "other/add_output.hpp"
+
+const auto addOutputParams =
+    ::testing::Combine(::testing::Values("Memory_1"), ::testing::Values(CommonTestUtils::DEVICE_CPU));
+
+INSTANTIATE_TEST_CASE_P(AddOutputBasic, AddOutputTestsCommonClass, addOutputParams,
+                        AddOutputTestsCommonClass::getTestCaseName);
+
+TEST_P(AddOutputTestsCommonClass, basic) {
+    run_test();
+}

--- a/inference-engine/tests/functional/plugin/gna/shared_tests_instances/other_tests/add_output.cpp
+++ b/inference-engine/tests/functional/plugin/gna/shared_tests_instances/other_tests/add_output.cpp
@@ -1,0 +1,15 @@
+// Copyright (C) 2020 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "other/add_output.hpp"
+
+const auto addOutputParams =
+    ::testing::Combine(::testing::Values("Memory_1"), ::testing::Values(CommonTestUtils::DEVICE_GNA));
+
+INSTANTIATE_TEST_CASE_P(AddOutputBasic, AddOutputTestsCommonClass, addOutputParams,
+                        AddOutputTestsCommonClass::getTestCaseName);
+
+TEST_P(AddOutputTestsCommonClass, basic) {
+    run_test();
+}

--- a/inference-engine/tests/functional/plugin/shared/include/other/add_output.hpp
+++ b/inference-engine/tests/functional/plugin/shared/include/other/add_output.hpp
@@ -1,0 +1,26 @@
+// Copyright (C) 2020 Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include <gtest/gtest.h>
+
+#include <map>
+
+#include "common_test_utils/common_layers_params.hpp"
+#include "common_test_utils/common_utils.hpp"
+#include "common_test_utils/test_common.hpp"
+#include "common_test_utils/test_constants.hpp"
+#include "common_test_utils/xml_net_builder/ir_net.hpp"
+#include "common_test_utils/xml_net_builder/xml_filler.hpp"
+#include "ie_core.hpp"
+
+class AddOutputTestsCommonClass : public CommonTestUtils::TestsCommon,
+                                  public testing::WithParamInterface<std::tuple<std::string, std::string>> {
+private:
+    static std::string generate_model();
+
+public:
+    static std::string getTestCaseName(testing::TestParamInfo<std::tuple<std::string, std::string>> obj);
+    void run_test();
+};

--- a/inference-engine/tests/functional/plugin/shared/src/other/add_output.cpp
+++ b/inference-engine/tests/functional/plugin/shared/src/other/add_output.cpp
@@ -1,0 +1,76 @@
+// Copyright (C) 2020 Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "other/add_output.hpp"
+
+// TODO: Replace IRBuilder with NGraph when it supports Memory Layer
+std::string AddOutputTestsCommonClass::generate_model() {
+    CommonTestUtils::IRBuilder_v6 test_model_builder("model");
+
+    auto precision = InferenceEngine::Precision::FP32;
+
+    auto Memory_1_layer =
+        test_model_builder.AddLayer("Memory_1", "Memory", precision, {{"id", "r_1-3"}, {"index", "1"}, {"size", "2"}})
+            .AddOutPort({1, 200})
+            .getLayer();
+    auto Input_2_layer = test_model_builder.AddLayer("Input_2", "input", precision).AddOutPort({1, 200}).getLayer();
+    auto Eltwise_3_layer = test_model_builder.AddLayer("Eltwise_3", "Eltwise", precision, {{"operation", "mul"}})
+                               .AddInPort({1, 200})
+                               .AddInPort({1, 200})
+                               .AddOutPort({1, 200})
+                               .getLayer();
+
+    auto Activation_4_layer =
+        test_model_builder.AddLayer("Activation_4", "Activation", precision, {{"type", "sigmoid"}})
+            .AddInPort({1, 200})
+            .AddOutPort({1, 200})
+            .getLayer();
+    auto Memory_5_layer =
+        test_model_builder.AddLayer("Memory_5", "Memory", precision, {{"id", "r_1-3"}, {"index", "0"}, {"size", "2"}})
+            .AddInPort({1, 200})
+            .getLayer();
+
+    test_model_builder.AddEdge(Memory_1_layer.out(0), Eltwise_3_layer.in(0));
+    test_model_builder.AddEdge(Input_2_layer.out(0), Eltwise_3_layer.in(1));
+    test_model_builder.AddEdge(Eltwise_3_layer.out(0), Activation_4_layer.in(0));
+    test_model_builder.AddEdge(Activation_4_layer.out(0), Memory_5_layer.in(0));
+
+    auto serial = test_model_builder.serialize();
+
+    return serial;
+}
+
+std::string AddOutputTestsCommonClass::getTestCaseName(
+    testing::TestParamInfo<std::tuple<std::string, std::string>> obj) {
+    std::string layer;
+    std::string engine;
+
+    std::tie(layer, engine) = obj.param;
+    return layer + "_" + engine;
+}
+
+void AddOutputTestsCommonClass::run_test() {
+    std::string layer_name;
+    std::string engine_type;
+
+    std::tie(layer_name, engine_type) = this->GetParam();
+
+    auto model = this->generate_model();
+
+    InferenceEngine::Core ie;
+    InferenceEngine::CNNNetwork network;
+    InferenceEngine::ExecutableNetwork executableNet;
+
+    auto null_blob = CommonTestUtils::getWeightsBlob(0);
+    network = ie.ReadNetwork(model, null_blob);
+    network.addOutput(layer_name);
+    executableNet = ie.LoadNetwork(network, engine_type);
+
+    auto outputs = executableNet.GetOutputsInfo();
+
+    auto layer_output = outputs[layer_name];
+
+    ASSERT_EQ(true, layer_output && "layer not found in outputs");
+}


### PR DESCRIPTION
Following patches will fix the following issues
- Add a output layer to memory layer
- Reduce the errors for sigmoid function for input values near zero